### PR TITLE
Reset-napin upgradea, styleitten kasaamista, skinien "osto"

### DIFF
--- a/screens/highscoreScreen.js
+++ b/screens/highscoreScreen.js
@@ -36,7 +36,7 @@ export default function HighscoreScreen({ points, onReturn, navigation }) {
             const savedScores = await AsyncStorage.getItem('HIGHSCORES');// Haetaan tallennetut highscoret
             let scoresArray = savedScores ? JSON.parse(savedScores) : [];
             // Järjestetään tulokset laskevaan järjestykseen ja pidetään vain top 10
-            return scoresArray.sort((a, b) => b - a).slice(0, 10);
+            return scoresArray.sort((a, b) => b - a).slice(0 ,10);
         } catch (e) {
             console.error("Highscorejen lataaminen epäonnistui", e);
             return [];

--- a/screens/mainMenuScreen.js
+++ b/screens/mainMenuScreen.js
@@ -1,57 +1,34 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, ImageBackground, StyleSheet } from 'react-native';
+import DarkTheme from '../styles/theme';
+import { useTheme } from '../components/Theme';
+
 
 export default function MainMenuScreen({ navigation }) {
+const { isDarkMode, toggleDarkMode, setIsDarkMode } = useTheme();
+const styles = DarkTheme(isDarkMode);
     return (
     <ImageBackground
       source={require('../assets/Taustakuva.jpg')} 
       style={styles.background}
     >
-      <View style={styles.container}>
-        <TouchableOpacity style={styles.Button} onPress={() => { navigation.navigate('Game') }}>
-            <Text style={styles.ButtonText}>PLAY</Text>
+      <View style={styles.containerMainMenu}>
+        <TouchableOpacity style={styles.ButtonMainMenu} onPress={() => { navigation.navigate('Game') }}>
+            <Text style={styles.ButtonMainMenuText}>PLAY</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.Button} onPress={() => { navigation.navigate('Highscore') }}>
-            <Text style={styles.ButtonText}>HIGHSCORES</Text>
+        <TouchableOpacity style={styles.ButtonMainMenu} onPress={() => { navigation.navigate('Highscore') }}>
+            <Text style={styles.ButtonMainMenuText}>HIGHSCORES</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.Button} onPress={() => navigation.navigate('Options')}>
-            <Text style={styles.ButtonText}>OPTIONS</Text>
+        <TouchableOpacity style={styles.ButtonMainMenu} onPress={() => navigation.navigate('Options')}>
+            <Text style={styles.ButtonMainMenuText}>OPTIONS</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.Button} onPress={() => navigation.navigate('Shop')}>
-            <Text style={styles.ButtonText}>SHOP</Text>
+        <TouchableOpacity style={styles.ButtonMainMenu} onPress={() => navigation.navigate('Shop')}>
+            <Text style={styles.ButtonMainMenuText}>SHOP</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.Button}  onPress={() => navigation.goBack()}>
-            <Text style={styles.ButtonText}>Return</Text>
+        <TouchableOpacity style={styles.ButtonMainMenu}  onPress={() => navigation.goBack()}>
+            <Text style={styles.ButtonMainMenuText}>Return</Text>
         </TouchableOpacity>
       </View>
     </ImageBackground>
   );
 };
-
-const styles = StyleSheet.create({
-  background: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
-    height: '100%',
-  },
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative', 
-  },
-  Button: {
-    backgroundColor: 'red',
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-    marginBottom: 10
-  },
-  ButtonText: {
-    color: '#fff',
-    fontSize: 24,
-    fontWeight: 'bold',
-  },
-});

--- a/screens/optionScreen.js
+++ b/screens/optionScreen.js
@@ -11,7 +11,6 @@ const OptionScreen = ({ navigation }) => {
 
   const { isDarkMode, toggleDarkMode, setIsDarkMode } = useTheme();
   const styles = DarkTheme(isDarkMode);
-
   const [isConfirm, setIsConfirm] = useState(false);
 
   
@@ -37,7 +36,7 @@ const OptionScreen = ({ navigation }) => {
         const savedTheme = await AsyncStorage.getItem('darkMode');
         const savedMusic = await AsyncStorage.getItem('MusicOn');
         const savedSfx = await AsyncStorage.getItem('SfxOn');
-
+        const savedSkins = await AsyncStorage.getItem('purchasedSkins');
         if (savedTheme !== null) {
           setIsDarkMode(savedTheme === 'true');
         }
@@ -48,6 +47,10 @@ const OptionScreen = ({ navigation }) => {
 
         if (savedSfx !== null) {
           setIsSfxOn(savedSfx === 'true');
+        }
+
+        if (savedSkins !== null) {
+          const purchasedSkins = JSON.parse(savedSkins);
         }
       } catch (error) {
         console.error("Error loading settings:", error);
@@ -82,6 +85,7 @@ const OptionScreen = ({ navigation }) => {
       await AsyncStorage.removeItem('HIGHSCORES');
       await AsyncStorage.removeItem('MusicOn');
       await AsyncStorage.removeItem('SfxOn');
+      await AsyncStorage.removeItem('purchasedSkins'); 
       setIsDarkMode(false);
       setIsMusicOn(false);
       setIsSfxOn(false);

--- a/screens/optionScreen.js
+++ b/screens/optionScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Alert} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import DarkTheme from '../styles/theme';
 import { useTheme } from '../components/Theme';
@@ -7,9 +7,29 @@ import { useTheme } from '../components/Theme';
 const OptionScreen = ({ navigation }) => {
   const [MusicOn, setIsMusicOn] = useState(false);
   const [SfxOn, setIsSfxOn] = useState(false);
+  
 
   const { isDarkMode, toggleDarkMode, setIsDarkMode } = useTheme();
   const styles = DarkTheme(isDarkMode);
+
+  const [isConfirm, setIsConfirm] = useState(false);
+
+  
+  const ResetData = () => {
+    Alert.alert(
+      "Are you sure?",
+      "Do you really want to reset all data?",
+      [
+          {
+              text: "Cancel",
+          },
+          {
+              text: "Yes", 
+              onPress: () => resetData()
+          }
+      ]
+  );
+};
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -65,7 +85,7 @@ const OptionScreen = ({ navigation }) => {
       setIsDarkMode(false);
       setIsMusicOn(false);
       setIsSfxOn(false);
-      alert('Data reset successfully!');
+      Alert.alert('Data reset successfully!', 'Good Luck & Have Fun!');
     } catch (error) {
       console.error("Error resetting data:", error);
     }
@@ -75,6 +95,7 @@ const OptionScreen = ({ navigation }) => {
     <View style={styles.container}>
       <Text style={styles.title}>Options</Text>
       <View style={styles.optionsContainer}>
+        
         <View style={styles.Row}>
           <Text style={styles.Label}>Music</Text>
           <TouchableOpacity style={[styles.button, MusicOn && styles.activeButton]} onPress={toggleMusic}>
@@ -90,17 +111,17 @@ const OptionScreen = ({ navigation }) => {
         </View>
 
         <View style={styles.Row}>
-          <Text style={styles.Label}>Dark Mode</Text>
-          <TouchableOpacity style={styles.button} onPress={toggleDarkMode}>
+          <Text style={styles.Label}>DarkMode</Text>
+          <TouchableOpacity style={[styles.button, isDarkMode && styles.activeButton]} onPress={toggleDarkMode}>
             <Text style={styles.buttonTitle}>{isDarkMode ? "On" : "Off"}</Text>
           </TouchableOpacity>
         </View>
       </View>
-      <TouchableOpacity style={styles.resetButton} onPress={resetData}>
+      <TouchableOpacity style={[styles.button, styles.resetButton]} onPress={ResetData}>
         <Text style={styles.buttonTitle}>RESET DATA</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.returnButton} onPress={() => navigation.goBack()}>
+      <TouchableOpacity style={[styles.button, styles.returnButton]} onPress={() => navigation.goBack()}>
         <Text style={styles.buttonTitle}>Return</Text>
       </TouchableOpacity>
     </View>

--- a/screens/shopScreen.js
+++ b/screens/shopScreen.js
@@ -32,8 +32,8 @@ const ShopScreen = ({ onReturn, navigation }) => {
       </View>
 
 
-      <Text style={styles.label}>Name: </Text>
-      <Text style={styles.label}>Price: </Text>
+      <Text style={styles.Label}>Name: </Text>
+      <Text style={styles.Label}>Price: </Text>
 
       <TouchableOpacity style={[styles.button, styles.BButton]} onPress={() => alert('Osto nappi toimii')}>
         <Text style={styles.buttonTitle}>Buy</Text>

--- a/screens/shopScreen.js
+++ b/screens/shopScreen.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 import DarkTheme from '../styles/theme';
 import { useTheme } from '../components/Theme';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
 //Skinien importit 
 import S1 from '../assets/S1.png';
 import S2 from '../assets/S2.png';
@@ -14,28 +16,76 @@ import S8 from '../assets/S8.png';
 const ShopScreen = ({ onReturn, navigation }) => {
 
   const Skins = [S1, S2, S3, S4, S5, S6, S7, S8];
+  const SkinPrices = [1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500]; 
+
   const { isDarkMode, toggleDarkMode, setIsDarkMode } = useTheme();
   const styles = DarkTheme(isDarkMode);
 
-  // LISÄÄ TOIMINNALLISUUS JA TARVITTAESSA POISTA ALERT POIS!
+  const [selectedSkin, setSelectedSkin] = useState(null)
+  const [purchasedSkins, setPurchasedSkins] = useState([])
+//ladataan tiedot
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const mySkins = await AsyncStorage.getItem('purchasedSkins');
+        if (mySkins) {
+          setPurchasedSkins(JSON.parse(mySkins));
+        }
+      } catch (error) {
+        console.error("Error loading purchased skins", error);
+      }}
+      loadData();
+    }, []);
+//tallennetaan tiedot
+  useEffect(() => {
+    const saveData = async () => {
+      try {
+        await AsyncStorage.setItem('purchasedSkins', JSON.stringify(purchasedSkins))
+      } catch (error) {
+        console.error("Error saving purchased skins", error)
+      }
+    }; saveData();
+  }, [purchasedSkins]);
+
+  const selectSkin = (index) => {
+    if (!purchasedSkins.includes(index)) {
+      setSelectedSkin(index);
+  }
+};
+
+const handlePurchase = () => {
+  if (selectedSkin === null) {
+    return;
+  }
+
+    setPurchasedSkins([...purchasedSkins, selectedSkin]);
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Shop</Text>
+     <Text style={styles.title}>Shop</Text>
+     <Text style={styles.Label}>Your Coins: {}</Text>
 
+    <View style={styles.skinsContainer}>
+     {Skins.map((skin, index) => {
+     const isPurchased = purchasedSkins.includes(index);
+     const isSelected = selectedSkin === index;
+      return (
+     <TouchableOpacity key={index} style={[ styles.skinBox, isSelected && styles.selectedSkinBox,  isPurchased && styles.purchased, ]}
+      onPress={!isPurchased ? () => selectSkin(index) : null} >
+      <Image source={skin} style={[styles.skinImage, isPurchased && styles.purchasedSkin]} />
+     </TouchableOpacity>
+      )})}
+    </View>
 
-      <View style={styles.skinsContainer}>
-        {Skins.map((skin, index) => (
-          <TouchableOpacity key={index} style={styles.skinBox} onPress={() => alert('Skiniä painettu :D')}>
-            <Image source={skin} style={styles.skinImage} />
-          </TouchableOpacity>
-        ))}
-      </View>
+    {selectedSkin !== null && (
+            <>
+              <Text style={styles.Label}>Name: Skin {selectedSkin + 1}</Text>
+              <Text style={styles.Label}>Price: {SkinPrices[selectedSkin]} Coins</Text>
+            </>
+          )}
 
-
-      <Text style={styles.Label}>Name: </Text>
-      <Text style={styles.Label}>Price: </Text>
-
-      <TouchableOpacity style={[styles.button, styles.BButton]} onPress={() => alert('Osto nappi toimii')}>
+      <TouchableOpacity style={[styles.button, styles.BButton]} onPress={handlePurchase}>
         <Text style={styles.buttonTitle}>Buy</Text>
       </TouchableOpacity>
       {/*  

--- a/screens/startScreen.js
+++ b/screens/startScreen.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, ImageBackground, StyleSheet } from 'react-native';
+import DarkTheme from '../styles/theme';
+import { useTheme } from '../components/Theme';
 
 export default function StartScreen({ navigation }) {
+  const { isDarkMode, toggleDarkMode, setIsDarkMode } = useTheme();
+const styles = DarkTheme(isDarkMode);
+
     return (
     <ImageBackground
       source={require('../assets/Taustakuva.jpg')} 
       style={styles.background}
     >
-      <View style={styles.container}>
+      <View style={styles.containerMainMenu}>
         <TouchableOpacity style={styles.startButton} onPress={() => { navigation.navigate('MainMenu') }}>
           <Text style={styles.startButtonText}>START</Text>
         </TouchableOpacity>
@@ -15,32 +20,3 @@ export default function StartScreen({ navigation }) {
     </ImageBackground>
   );
 };
-
-const styles = StyleSheet.create({
-  background: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
-    height: '100%',
-  },
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative', 
-  },
-  startButton: {
-    backgroundColor: 'red',
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-    position: 'absolute',  
-    bottom: '10%', 
-  },
-  startButtonText: {
-    color: '#fff',
-    fontSize: 24,
-    fontWeight: 'bold',
-  },
-});

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -110,6 +110,16 @@ const DarkTheme = (isDarkMode) => {
       width: '100%',
       height: '100%',
     },
+    purchased: {
+      opacity: 0.5,
+    },
+    purchasedSkin: {
+      tintColor: 'gray'
+    },
+    selectedSkinBox: {
+      borderWidth: 3,
+      borderColor: 'gold',
+    },
   };
 };
 

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -120,6 +120,49 @@ const DarkTheme = (isDarkMode) => {
       borderWidth: 3,
       borderColor: 'gold',
     },
+
+    //Mainmenu
+    background: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      height: '100%',
+    },
+    containerMainMenu: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      position: 'relative', 
+    },
+    ButtonMainMenu: {
+      backgroundColor: 'red',
+      paddingVertical: 15,
+      paddingHorizontal: 30,
+      borderRadius: 10,
+      marginBottom: 10
+    },
+    ButtonMainMenuText: {
+      color: '#fff',
+      fontSize: 24,
+      fontWeight: 'bold',
+    },
+
+    //StartScreen
+
+  startButton: {
+      backgroundColor: 'red',
+      paddingVertical: 15,
+      paddingHorizontal: 30,
+      borderRadius: 10,
+      position: 'absolute',  
+      bottom: '10%', 
+    },
+    startButtonText: {
+      color: '#fff',
+      fontSize: 24,
+      fontWeight: 'bold',
+    },
   };
 };
 

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -18,7 +18,6 @@ const DarkTheme = (isDarkMode) => {
     },
     list: {
       width: '100%',
-
     },
     item: {
       flexDirection: 'row',
@@ -89,18 +88,12 @@ const DarkTheme = (isDarkMode) => {
       fontSize: 30,
       textAlign: 'center'
     },
-
+ //Optionsview
     optionsContainer: {
       flex: 1,
       justifyContent: 'center',
     },
 
-    darkContainer: {
-      backgroundColor: 'black',
-    },
-    darkText: {
-      color: 'white',
-    },
     //SKINIT
     skinsContainer: {
       flexDirection: 'row',


### PR DESCRIPTION
RESET DATA- nappi nyt resettää highscoret, asetukset, "ostetut" skinit. 
Siiretty Mainmenuscreenistä ja startscreenistä stylet theme.js kansioon.
Shopissa voi nyt "ostaa" skinejä.. Toiminta pitää lisätä että niitä voi käyttää ja pelata niillä. 
Lisätä pitää että ostossa tarvii coinseja. 
"ostetut" skinit muuttuu harmaaksi joten niitä ei voi ostaa uuelleen. 
Painamalla skiniä tulee kullatut reunat jotta tietää mitä skiniä on ostamassa ja myös painamalla skiniä saa hinta tiedot ja skinin nimen. 